### PR TITLE
Fixed multiple reconnection

### DIFF
--- a/lib/zookeeper-watcher.js
+++ b/lib/zookeeper-watcher.js
@@ -46,8 +46,14 @@ util.inherits(ZooKeeperWatcher, EventEmitter);
 ZooKeeperWatcher.prototype._newZK = function () {
   var self = this;
   var zk = zookeeper.createClient(this.connectionString, this.options);
+  var handleCloseCalled = false;
   var handleClose = function () {
-    debug('[%s] zk closed, close All: %s, %d ms reconncet', Date(), !!self.__closeAll, self._reconnectTimeout);
+    if (handleCloseCalled) {
+      return;
+    }
+    handleCloseCalled = true;
+
+    debug('[%s] zk closed, close All: %s, %d ms reconnect', Date(), !!self.__closeAll, self._reconnectTimeout);
     if (self.__closeAll) {
       // Use call ZooKeeperWatcher.close()
       return;


### PR DESCRIPTION
``` js
  zk.once('expired', handleClose);
  zk.once('disconnected', handleClose);
```

are called same time

Connections are multiplied after reconnectTimeout

There is test https://gist.github.com/falsecz/e3df9a7f2bcf5fce686b
