### PR TITLE
node-zookeeper-client already handles disconnects

### DIFF
--- a/lib/zookeeper-watcher.js
+++ b/lib/zookeeper-watcher.js
@@ -46,29 +46,16 @@ util.inherits(ZooKeeperWatcher, EventEmitter);
 ZooKeeperWatcher.prototype._newZK = function () {
   var self = this;
   var zk = zookeeper.createClient(this.connectionString, this.options);
-  var handleCloseCalled = false;
   var handleClose = function () {
-    if (handleCloseCalled) {
-      return;
-    }
-    handleCloseCalled = true;
-
-    debug('[%s] zk closed, close All: %s, %d ms reconnect', Date(), !!self.__closeAll, self._reconnectTimeout);
-    if (self.__closeAll) {
-      // Use call ZooKeeperWatcher.close()
-      return;
-    }
-    !zk.__closed && zk.close();
-    zk.__closed = true;
-    // create new zk client
-    setTimeout(self._newZK.bind(self), self._reconnectTimeout);
+    debug('[%s] zk disconnected', Date());
   };
-  zk.once('expired', handleClose);
-  zk.once('disconnected', handleClose);
 
   self.zk = zk;
 
-  zk.once('connected', function () {
+  zk.on('expired', handleClose);
+  zk.on('disconnected', handleClose);
+  zk.on('connected', function () {
+    debug('[%s] zk connected', Date());
     if (self._watchPaths.length > 0) {
       debug('[%s] connected, auto watch %j', Date(), self._watchPaths);
       // watch again


### PR DESCRIPTION
node-zookeeper-client is already handling disconnects and to everyone else, it appears either connected or connecting, so no need to handle it in the watcher

the problem is that we are experiencing increasing number of connections when restarting zookeeper where client reconnects after 2-3seconds, and then watcher creates new connection after 20secs (my guess is that this.zk.close() doesn't really work as you hoped).. and this happens all the time

can you please review this?