### PR TITLE
Don't create new zk client on states: closing, expire, auth_failed

### DIFF
--- a/lib/zookeeper-watcher.js
+++ b/lib/zookeeper-watcher.js
@@ -48,7 +48,8 @@ ZooKeeperWatcher.prototype._newZK = function () {
   var zk = zookeeper.createClient(this.connectionString, this.options);
   var handleCloseCalled = false;
   var handleClose = function () {
-    if (handleCloseCalled) {
+    // create new zk client only on closing, session_expired and authentication_failed (others are handled by node-zookeeper-client)
+    if (handleCloseCalled || !(zk.connectionManager.state == -1 || zk.connectionManager.state == -3 || zk.connectionManager.state == -4)) {
       return;
     }
     handleCloseCalled = true;


### PR DESCRIPTION
node-zookeeper-client is already handling disconnects and to everyone else, it appears either connected or connecting (https://github.com/alexguan/node-zookeeper-client/pull/15#issuecomment-29363921), so there's no need to handle it in the watcher.. this doesn't apply on states: closing, expire, auth_failed

the problem is that we are experiencing increasing number of connections when restarting zookeeper where client reconnects after 2-3seconds, and then watcher creates new connection after 20secs

can you please review this?